### PR TITLE
add override for bobmonium chunk to produce nitric acid waste water

### DIFF
--- a/angelsrefining_0.9.14/prototypes/refining-override.lua
+++ b/angelsrefining_0.9.14/prototypes/refining-override.lua
@@ -49,6 +49,7 @@ else if angelsmods.trigger.enableacids then
       { name = "angelsore2-chunk", results = {{ name = "water-greenyellow-waste", type = "fluid", amount = "water-yellow-waste" }} },
       { name = "angelsore4-chunk", results = {{ name = "water-green-waste", type = "fluid", amount = "water-yellow-waste" }} },
       { name = "angelsore5-chunk", results = {{ name = "water-red-waste", type = "fluid", amount = "water-yellow-waste" }} },
+      { name = "angelsore6-chunk", results = {{ name = "water-red-waste", type = "fluid", amount = "water-yellow-waste" }} },
       { name = "greenyellow-waste-water-purification", results = {{ "fluorite-ore" }} },
    })
 	else


### PR DESCRIPTION
Playing with Bob's and Angle's (including petrochemical) with fluids required for infinite ores.

Bobmonium mining requires nitric acid, while the flotation cell produces sulfuric waste water.
The other recipes are all consistent between the acid used for mining and the waste water produced.

There's a lot going on in these mods, so I'm not sure where in the code is the best place to make this consistent, but it looks like it might be right here: by overriding the chunk recipe to output nitric acid.

This would leave bobmonium requiring nitric acid to mine, but also produce nitric waste water when chunks are sorted in a flotation cell. This is identical to the behavior of rubyte.

I think that I got EN locales correct, but should definitely double check me.

`anglesore6` is Bobmonium
`anglesore5` is Rubyte
`water-red-waste` is nitric acid

I suspect this was a minor orversight/bug, but it could have been intentional. Proposing the change. Let me know what you think.